### PR TITLE
add_gosqaured_script now checks for HTML response before injecting sc…

### DIFF
--- a/lib/tracker_inject/injector.rb
+++ b/lib/tracker_inject/injector.rb
@@ -1,39 +1,45 @@
-  class Injector
+class Injector
+  module Filter
+    extend ActiveSupport::Concern
+    included do
+      append_after_filter :add_gosquared_script, :if => :html_response?
 
-    module Filter
-      extend ActiveSupport::Concern
-      included do
-        append_after_filter :add_script
+      CLOSING_HEAD_TAG = %r{</body>}
 
-        CLOSING_BODY_TAG = %r{</body>}
+      def add_gosquared_script
+        response.body = response.body.gsub(CLOSING_HEAD_TAG, "<script type='text/javascript' async='true'>
+          var trackingCode = function(){
+            !function(g,s,q,r,d){r=g[r]=g[r]||function(){(r.q=r.q||[]).push(
+              arguments)};d=s.createElement(q);q=s.getElementsByTagName(q)[0];
+        d.src='//d1l6p2sc9645hc.cloudfront.net/tracker.js';q.parentNode.
+        insertBefore(d,q)}(window,document,'script','_gs');
+        _gs('GSN-589158-M'); _gs('set', 'trackLocal', true);
+        _gs('event', '#{request.headers["PATH_INFO"]}', {
+          extra: 'event',
+          details: true
+          });
+        };
 
-        def add_script
-          response.body = response.body.gsub(CLOSING_BODY_TAG, "<script>
-            var trackingCode = function() {
-
-              !function(g,s,q,r,d){r=g[r]=g[r]||function(){(r.q=r.q||[]).push(
-                arguments)};d=s.createElement(q);q=s.getElementsByTagName(q)[0];
-          d.src='//d1l6p2sc9645hc.cloudfront.net/tracker.js';q.parentNode.
-          insertBefore(d,q)}(window,document,'script','_gs');
-          _gs('#{Gosquared.configure.site_token}'); _gs('set', 'trackLocal', true);
-          };
-
-          var loadTracker;
-          loadTracker=function(){
-            if(!window._gs) {
+        var loadTracker;
+        loadTracker=function(){
+          if(!window._gs) {
+            trackingCode();
+            } else {
+              delete _gs;
               trackingCode();
-              } else {
-                delete _gs;
-                trackingCode();
-              }
-              };
-              $(document).on('page:load', loadTracker)
-              $(document).on('turbolinks:load', loadTracker);
-              </script>" + "\n </body>")
-
-        end
-
+            }
+            };
+            $(document).on('page:load', loadTracker)
+            $(document).on('turbolinks:load', loadTracker);
+            </script>" + "\n </body>"
+            )
       end
-    end
 
+      def html_response?
+        response.content_type == "text/html"
+      end
+
+    end
   end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ require 'webmock/rspec'
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/tracker_inject_spec.rb
+++ b/spec/tracker_inject_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+if defined?(Rails)
+
+  class ApplicationController < ActionController::Base
+
+    after_filter :add_gosquared_script, :if => :html_response?
+
+    def add_gosquared_script
+      response.body = response.body.gsub(CLOSING_HEAD_TAG, "<script type='text/javascript' async='true'>
+        var trackingCode = function(){
+          !function(g,s,q,r,d){r=g[r]=g[r]||function(){(r.q=r.q||[]).push(
+            arguments)};d=s.createElement(q);q=s.getElementsByTagName(q)[0];
+      d.src='//d1l6p2sc9645hc.cloudfront.net/tracker.js';q.parentNode.
+      insertBefore(d,q)}(window,document,'script','_gs');
+      _gs('GSN-589158-M'); _gs('set', 'trackLocal', true);
+      _gs('event', '#{request.headers["PATH_INFO"]}', {
+        extra: 'event',
+        details: true
+        });
+      };
+
+      var loadTracker;
+      loadTracker=function(){
+        if(!window._gs) {
+          trackingCode();
+          } else {
+            delete _gs;
+            trackingCode();
+          }
+          };
+          $(document).on('page:load', loadTracker)
+          $(document).on('turbolinks:load', loadTracker);
+          </script>" + "\n </body>"
+          )
+    end
+
+    def html_response?
+      response.content_type == "text/html"
+    end
+
+
+  end
+
+  describe ApplicationController, :type => :controller do
+    controller do
+      def index
+        render :html => true
+      end
+
+      def new
+        render :json => true
+      end
+
+
+    end
+
+    it "adds the GoSquared tracking code" do
+     expect(controller).to receive(:add_gosquared_script)
+     get :index
+   end
+
+   it "add the GoSquared tracking code" do
+     expect(controller).not_to receive(:add_gosquared_script)
+     get :new
+   end
+
+   it "add the GoSquared tracking code" do
+     expect(controller).not_to receive(:add_gosquared_script)
+     get :new
+   end
+
+ end
+
+end


### PR DESCRIPTION
…ript

- add validation check for HTML response before injecting script in lib/tracker_inject/injector.rb
- rename add_script filter from ‘add_script’ to ‘add_gosquared_script’  to avoid collisions with other filters
- add tracking_inject spec test