### PR TITLE
Removed spaces in the requests payload

### DIFF
--- a/lib/gosquared/client.rb
+++ b/lib/gosquared/client.rb
@@ -28,7 +28,7 @@ module Gosquared
   		https = Net::HTTP.new(uri.host, uri.port)
   		https.use_ssl = true
   		request = Net::HTTP::Post.new(uri.request_uri, initheader = {'Content-Type' =>'application/json', 'User-Agent' => 'ruby-client/'+ VERSION})
-      request.body = "[ #{data.to_json} ]"
+      request.body = "[#{data.to_json}]"
   		response = https.request(request)
   	rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
   		Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
@@ -50,7 +50,7 @@ module Gosquared
   		https = Net::HTTP.new(uri.host, uri.port)
   		https.use_ssl = true
   		request = Net::HTTP::Delete.new(uri.request_uri, initheader = {'Content-Type' =>'application/json'})
-  		request.body = "[ #{data.to_json} ]"
+  		request.body = "[#{data.to_json}]"
   		response = https.request(request)
   	rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
   		Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -33,11 +33,11 @@ describe Gosquared::Account do
 
 	before do
 		stub_request(:post, "https://api.gosquared.com/account/v1/blocked/ips?api_key=demo&ip=20.15.33.99&site_token=GSN-2194840-F").
-		with(:body => "[ \"\" ]",
+		with(:body => "[\"\"]",
 			:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json'}).
 		to_return(:status => 200, :body => "", :headers => {})
 		stub_request(:delete, "https://api.gosquared.com/account/v1/blocked/ips?api_key=demo&ip=20.15.33.99&site_token=GSN-2194840-F").
-		with(:body => "[ \"\" ]",
+		with(:body => "[\"\"]",
 			:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json'}).
 		to_return(:status => 200, :body => "", :headers => {})
 	end

--- a/spec/tracking_spec.rb
+++ b/spec/tracking_spec.rb
@@ -6,7 +6,7 @@ describe Gosquared::Tracking do
 	Gosquared::Tracking::DIMENSIONS.each do |dimension|
 		before do
 			stub_request(:post, "https://api.gosquared.com/tracking/v1/#{dimension}?api_key=demo&site_token=GSN-2194840-F").
-			with(:body => "[ {\"person_id\":\"email:test@example.com\",\"properties\":{\"email\":\"test@example.com\"}} ]",
+			with(:body => "[{\"person_id\":\"email:test@example.com\",\"properties\":{\"email\":\"test@example.com\"}}]",
 				:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'ruby-client/'+VERSION }).
 			to_return(:status => 200, :body => "", :headers => {response: "success"})
 		end
@@ -23,7 +23,7 @@ describe Gosquared::Tracking do
 	describe "#event" do
 		before do
 			stub_request(:post, "https://api.gosquared.com/tracking/v1/event?api_key=demo&site_token=GSN-2194840-F").
-			with(:body => "[ {\"event\":{\"name\":\"event\"}} ]",
+			with(:body => "[{\"event\":{\"name\":\"event\"}}]",
 				:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'ruby-client/'+VERSION}).
 			to_return(:status => 200, :body => "", :headers => {})
 			@data = {person_id: nil,  event: { name: 'event' } }
@@ -36,7 +36,7 @@ describe Gosquared::Tracking do
 
 		before do
 			stub_request(:post, "https://api.gosquared.com/tracking/v1/event?api_key=demo&site_token=GSN-2194840-F").
-			with(:body => "[ {\"person_id\":\"12345\",\"event\":{\"name\":\"event\"}} ]",
+			with(:body => "[{\"person_id\":\"12345\",\"event\":{\"name\":\"event\"}}]",
 				:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'ruby-client/'+VERSION}).
 			to_return(:status => 200, :body => "", :headers => {})
 			@data = {person_id: '12345',  event: { name: 'event' } }


### PR DESCRIPTION
I removed the spaces before and after the array brackets because they don't allow partial matching in testing.

Instead of doing this:

```
stub_request(:post, /api.gosquared.com\/tracking\/v1\/event/).
          with(body: [hash_including({
              person_id: "email:#{user.email}",
            })]).
to_return(status: 200, body: "")
```

You need to do some hacky thing like this:

```
stub_request(:post, /api.gosquared.com\/tracking\/v1\/event/).
          with(body: "[ #{{
              person_id: "email:#{user.email}",
              event: {
                name: 'Some event that you might not want to test but you need to in order to have a valid mock',
                data: {
                  wtv_data: 'random data',
                },
              }
            }.to_json} ]").
to_return(status: 200, body: "")
```